### PR TITLE
Looks like you have removed hljs from your site which breaks the generator

### DIFF
--- a/_includes/js/home_row_mods_code_generator.js
+++ b/_includes/js/home_row_mods_code_generator.js
@@ -118,7 +118,7 @@ function showTextField(name) {
 }
 
 function surroundInCodeBlock(code, language="c") {
-    return "<pre><code>" + hljs.highlight(language, code).value + "</code></pre>";
+    return "<pre><code>" + code + "</code></pre>";
 }
 
 function buildUserChoices(formElements, program="QMK") {


### PR DESCRIPTION
On the page https://precondition.github.io/home-row-mods#qmk-home-row-mods-code-generator you've created a generator I've tried generating on Chrome Safari and Safari iOS and they all don't work 

When clicking the "Generate" button you'll get the following console error.

```
ReferenceError: Can't find variable: hljs
```

I would figure if you remove the hljs code it would work fine, but I couldn't test it.

Hope it could be fixed, because I like to get me some code snippets.